### PR TITLE
NFT 카드 목록 sort 적용

### DIFF
--- a/src/hooks/useNFTList.ts
+++ b/src/hooks/useNFTList.ts
@@ -66,6 +66,7 @@ function useNFTList(): NFTCard[] {
       issuedNumber: 100,
     },
   ];
+
   return nftCard;
 }
 

--- a/src/pages/nft/index.tsx
+++ b/src/pages/nft/index.tsx
@@ -38,13 +38,45 @@ const sortOption = [
   { text: '제목 내림차순', value: 'desc' },
 ];
 
-const Nft: React.FC = () => {
+const sortData = ({
+  data,
+  option,
+}: {
+  data: NFTCard[];
+  option: { text: string; value: string };
+}) => {
+  const sortedData = data;
+
+  if (option.value === 'recent') {
+    sortedData.sort(function (a, b) {
+      return a.id - b.id;
+    });
+  } else if (option.value === 'old') {
+    sortedData.sort(function (a, b) {
+      return b.id - a.id;
+    });
+  } else if (option.value === 'asc') {
+    sortedData.sort(function (a, b) {
+      return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+    });
+  } else if (option.value === 'desc') {
+    sortedData.sort(function (a, b) {
+      return a.name > b.name ? -1 : a.name > b.name ? 1 : 0;
+    });
+  }
+
+  return sortedData;
+};
+
+const Nft: React.FC<NFTCard> = () => {
   const cardData = useNFTList();
 
   const { searchItem, handleSearch } = useSearch<NFTCard>();
 
   const searchedData = searchItem(cardData);
   const [sort, setSort] = useState(sortOption[0]);
+
+  const sortedData = sortData({ data: searchedData, option: sort });
 
   return (
     <Wrapper>
@@ -62,7 +94,7 @@ const Nft: React.FC = () => {
         >
           <Flex>
             <Input placeholder="검색" onChange={handleSearch} />
-            <div style={{ display: 'none' }}>
+            <div>
               <Sort
                 options={sortOption}
                 defaultValue={sort}
@@ -73,7 +105,7 @@ const Nft: React.FC = () => {
 
           <Spacer size={40} />
           <Grid>
-            {searchedData.map((card) => (
+            {sortedData.map((card) => (
               <Link key={card.id} href={`/nft/${card.id}`}>
                 <a>
                   <Card


### PR DESCRIPTION
NFT 카드 목록 화면에서 최신순/오래된 순/제목 오름차순/제목 내림차순 버튼을 누름에 따라 카드 목록의 순서가 바뀌도록 적용했습니다.